### PR TITLE
Remove dead function clause for parsing exponents

### DIFF
--- a/src/pgo_protocol.erl
+++ b/src/pgo_protocol.erl
@@ -256,21 +256,7 @@ parse_exp(<< Char:1/binary, Rest/binary>>) when Char =:= <<"e">> ->
             parse_digits(Rest, [])
     end;
 parse_exp(<<>>) ->
-    {[], <<>>};
-parse_exp(Bin) ->
-    case binary:first(Bin) of
-        "e" ->
-            Rest = binary:part(Bin, {1, byte_size(Bin) - 1 }),
-            case Rest of
-                <<Sign, Rest/binary>> when Sign =:= <<"+">> orelse Sign =:= <<"-">> ->
-                    {Digits, Rest} = parse_digits(Rest, []),
-                    {[Sign | Digits], Rest};
-                _ ->
-                    {[], Bin}
-            end;
-        _ ->
-            {[], Bin}
-    end.
+    {[], <<>>}.
 
 encode_digits(Coef, Digits) ->
     case Coef < 10000 of

--- a/test/pgo_basic_SUITE.erl
+++ b/test/pgo_basic_SUITE.erl
@@ -222,6 +222,9 @@ numerics(_Config) ->
     ?assertMatch(#{rows := [{-1.0e-11}]}, pgo:query(BasicQuery, [-0.00000000001])),
     ?assertMatch(#{rows := [{1.0e-32}]}, pgo:query(BasicQuery, [1.0e-32])),
 
+    ?assertMatch(#{rows := [{1.0e-32}]}, pgo:query(BasicQuery, [<<"1.0e-32">>])),
+    ?assertMatch(#{rows := [{1.0e+32}]}, pgo:query(BasicQuery, [<<"1.0e+32">>])),
+
 
      #{command := create} = pgo:query("create table numeric_tmp (id integer primary key, a_int integer, a_num numeric,
                                       b_num numeric(5,3))"),


### PR DESCRIPTION
Also added a few more assertions where we pass in a binary for the bind param for good measure. 