### PR TITLE
Include trace configuration in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ A [Telemetry](https://github.com/beam-telemetry/telemetry) event `[pgo, query]` 
 > pgo:start_pool(default, #{host => "127.0.0.1", 
                             database => "test", 
                             user => "test",
-                            pool_size => 5}]). 
+                            pool_size => 5,
+                            trace_default => true}]). 
 ```
 
 Or by passing `#{trace => true}` in the options for a query or transaction:


### PR DESCRIPTION
I didn't understand the example given the text above. Was there a mistake and this is what it is supposed to be?