### PR TITLE
Add table as possible return type for num_rows

### DIFF
--- a/src/pgo.erl
+++ b/src/pgo.erl
@@ -31,7 +31,7 @@
               decode_fun/0]).
 
 -type result() :: #{command := atom(),
-                    num_rows := integer(),
+                    num_rows := integer() | table,
                     rows := list()} | {error, error()} | {error, any()}.
 
 -type error() :: {pgo_error, #{error_field() => binary()}} | pg_types:encoding_error().


### PR DESCRIPTION
The result of running the SQL "CREATE TABLE cats3 (id INTEGER PRIMARY KEY)" does not return an integer number of rows