### PR TITLE
fix: add pool_options to options()

### DIFF
--- a/src/pgo.erl
+++ b/src/pgo.erl
@@ -46,11 +46,14 @@
                          column_name_as_atom | {column_name_as_atom, boolean()} |
                          {decode_fun, decode_fun()}.
 
--type pool_option() :: queue | {queue, boolean()}.
+-type pool_option() :: queue |
+                       {queue, boolean()} |
+                       {timeout, non_neg_integer()}.
 -type options() :: #{pool => atom(),
                      trace => boolean(),
                      queue => boolean(),
-                     decode_opts => [decode_option()]}.
+                     decode_opts => [decode_option()],
+                     pool_options => [pool_option()]}.
 
 -type pool_config() :: #{host => string(),
                          port => integer(),


### PR DESCRIPTION
- The `pool_options` field is missing in the `options()` type.
- `timeout` is a valid `pool_option()`, see https://github.com/erleans/pgo/blob/master/src/pgo.erl#L95.