### PR TITLE
Added an optional DB connector file to standardize the connections from the app to PGO. 

### DIFF
--- a/src/db_connector.erl
+++ b/src/db_connector.erl
@@ -1,0 +1,23 @@
+%% Feel free to use, reuse and abuse the code in this file.
+%%
+%% The purpose of the DB Connector is to have a standard interface for the rest of the app to communicate with PGO.
+%% This will make it easy to reflect any changes in the return type of PGO
+%% Or to replace another tool with PGO, or vice versa. 
+%% So the app calls functions defined in a "helper" file.
+%% And the helper file communicates with PGO via the connector. 
+
+%% @doc PGO connector
+
+-module(db_connector).
+-export([simple_query/1, extended_query/2]).
+
+simple_query(Query) -> 
+    #{command := Command, num_rows := NumRows, rows := Result} = 
+        pgo:query(Query, [], #{decode_opts => 
+        [return_rows_as_maps, column_name_as_atom]} ),
+    #{command => Command, num_rows => NumRows, result => Result}.
+
+extended_query(Query, ParamList) ->
+    #{command := Command, num_rows := NumRows, rows := Result} = 
+        pgo:query(Query, ParamList, #{decode_opts => [return_rows_as_maps, column_name_as_atom]}),
+    #{command => Command, num_rows => NumRows, result => Result}.

--- a/src/db_connector.erl
+++ b/src/db_connector.erl
@@ -1,10 +1,10 @@
 %% Feel free to use, reuse and abuse the code in this file.
 %%
 %% The purpose of the DB Connector is to have a standard interface for the rest of the app to communicate with PGO.
-%% This will make it easy to reflect any changes in the return type of PGO
+%% This will make it easy to reflect any changes in the return type of PGO (e.g. when it moved from returning tuples to maps)
 %% Or to replace another tool with PGO, or vice versa. 
-%% So the app calls functions defined in a "helper" file.
-%% And the helper file communicates with PGO via the connector. 
+%% So the app calls functions defined in a "helper" file. 
+%% And the helper file communicates with PGO via the connector. So in case of any changes with PGO, only this connector file needs to be updated, and not every pgo:query call.
 
 %% @doc PGO connector
 


### PR DESCRIPTION
The purpose of the optional DB Connector is to have a standard interface for the rest of the app to communicate with PGO. This will make it easy to reflect any changes in the return type of PGO (e.g. when it moved from returning tuples to maps). Or to replace another tool with PGO, or vice versa. So the app calls functions defined in a "helper" file. And the helper file communicates with PGO via the connector. So in case of any changes with PGO, only this connector file needs to be updated, and not every `pgo:query` call. 