### PR TITLE
Fix infinite loop in pgo:transaction/2

### DIFF
--- a/src/pgo.erl
+++ b/src/pgo.erl
@@ -146,7 +146,8 @@ transaction(Fun) ->
 %% @equiv transaction(default, Fun, Options)
 -spec transaction(fun(() -> any()), options()) -> any() | {error, any()}.
 transaction(Fun, Options) when is_function(Fun) ->
-    transaction(Fun, Options).
+    Pool = maps:get(pool, Options, default),
+    transaction(Pool, Fun, Options).
 
 %% @doc Runs a function, passing it a connection, in a SQL transaction.
 -spec transaction(pool(), fun(() -> any()), options()) -> any() | {error, any()}.


### PR DESCRIPTION
`pgo:transaction/2` was calling itself instead of delegating to `pgo:transaction/3`.