### PR TITLE
Fix pgo_handler:decode_tag return value

### DIFF
--- a/src/pgo_handler.erl
+++ b/src/pgo_handler.erl
@@ -578,7 +578,8 @@ decode_tag(Tag) ->
             VerbDecoded = decode_verb(Verb),
             ObjectL = decode_object(Object),
             list_to_tuple([VerbDecoded | ObjectL]);
-        [Verb] -> decode_verb(Verb)
+        [Verb] ->
+            {decode_verb(Verb), nil}
     end.
 
 decode_verb(Verb) ->


### PR DESCRIPTION
When used with commands such as "SET" pgo_handler:decode_tag returned the 'set' atom alone instead of {set, nil} as is done for other commands that don't return any row count.