### PR TITLE
Add ensure_all_started to make it obvious you need the application

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ To try `pgo` simply modify `config/example.config` by replacing the `host`, `dat
 `default` is the name of the pool, `size` is the number of connections to create for the pool. Or you can start the pool through `pgo:start_pool/2` which creates it as a child of `pgo`'s simple one for one:
 
 ``` erlang
+> application:ensure_all_started(pgo).
+{ok,[]}
 > pgo:start_pool(default, #{pool_size => 5, host => "127.0.0.1", database => "test", user => "test"}). 
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To try `pgo` simply modify `config/example.config` by replacing the `host`, `dat
 
 ``` erlang
 > application:ensure_all_started(pgo).
-{ok,[]}
+{ok,[backoff,opentelemetry_api,pg_types,pgo]}
 > pgo:start_pool(default, #{pool_size => 5, host => "127.0.0.1", database => "test", user => "test"}). 
 ```
 


### PR DESCRIPTION
I was trying out `pgo` for the first time and was getting some really difficult and massive error messages. Luckily, I found this: https://erlangforums.com/t/getting-errors-connecting-to-postgresql-reason-for-termination-error-badmatch-undefined/1760.

Here, I am adding a very basic `application:ensure_all_started(pgo).` to the instructions to make it more obvious that you need to start the application as well as start the pool in the application's supervisor (or via the shell).

This might be obvious to many, but it wasn't obvious as a newcomer to Erlang. As far as I can tell, `pgo` is the only PG client that actually explains how to start it which is really nice. 