### PR TITLE
Update github actions runner to ubuntu 22.04

### DIFF
--- a/.github/workflows/ct.yml
+++ b/.github/workflows/ct.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         otp_version: ['24.3.4']
         rebar3_version: ['3.18.0']
-        os: [ubuntu-18.04]
+        os: [ubuntu-22.04]
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
     steps:
@@ -63,7 +63,7 @@ jobs:
       matrix:
         otp_version: ['24.3.4']
         rebar3_version: ['3.18.0']
-        os: [ubuntu-18.04]
+        os: [ubuntu-22.04]
     steps:
     - uses: actions/checkout@v2
     - uses: erlef/setup-beam@v1


### PR DESCRIPTION
I got this failure message. In theory, CI may pass if you update the runners.

![image](https://github.com/erleans/pgo/assets/3086255/725f8665-b15b-4834-84b2-1841561849cc)
