### PR TITLE
Time zone should be explicitly set for timestamp related tests

### DIFF
--- a/src/pgo.app.src
+++ b/src/pgo.app.src
@@ -7,7 +7,6 @@
    [kernel,
     stdlib,
     backoff,
-    opentelemetry_api,
     pg_types
    ]},
   {env,[]},

--- a/src/pgo.app.src
+++ b/src/pgo.app.src
@@ -7,6 +7,7 @@
    [kernel,
     stdlib,
     backoff,
+    opentelemetry_api,
     pg_types
    ]},
   {env,[]},

--- a/test/pgo_datetime_SUITE.erl
+++ b/test/pgo_datetime_SUITE.erl
@@ -75,6 +75,8 @@ end_per_group(_, _Config) ->
     ok.
 
 select(_Config) ->
+    pgo:query("SET TIMEZONE TO 'UTC'"),
+    
     ?assertMatch(#{command := select,
                    rows := [{{2012,1,17}}]},
                  pgo:query("select '2012-01-17 10:54:03.45'::date")),


### PR DESCRIPTION
If you change this to `America/New_York` the test will fail. My machine by default was set to that.

```
> rebar3 ct --suite=test/pgo_datetime_SUITE.erl
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling pgo
===> Running Common Test suites...
%%% pgo_datetime_SUITE: ......
All 6 tests passed.
```